### PR TITLE
update gensim version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gensim==0.13.1
+gensim==0.13.2
 scipy==0.19.1
 wheel>=0.23.0
 Cython>=0.20.2


### PR DESCRIPTION
gensim==0.13.1 have warning:
"Warning: C extension not loaded for Word2Vec, training will be slow. Install a C compiler and reinstall gensim for fast training"

I think 0.13.1 version can't speed up word2vec with C extension.
while the latest version of gensim  is too high to support old attributes of word2vec which in HARP.
when I tried 0.13.2 version, it works!  Then HARP can run faster.